### PR TITLE
Refactoring Message entity, introducint MessageTypeEnum, fix fixtures

### DIFF
--- a/src/DataFixtures/AppFixtures.php
+++ b/src/DataFixtures/AppFixtures.php
@@ -3,10 +3,10 @@
 namespace App\DataFixtures;
 
 use App\Entity\Message;
+use App\Enum\MessageStatusEnum;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 use Faker\Factory;
-use Symfony\Component\Uid\Uuid;
 use function Psl\Iter\random;
 
 class AppFixtures extends Fixture
@@ -17,11 +17,9 @@ class AppFixtures extends Fixture
         
         foreach (range(1, 10) as $i) {
             $message = new Message();
-            $message->setUuid(Uuid::v6()->toRfc4122());
             $message->setText($faker->sentence);
-            $message->setStatus(random(['sent', 'read']));
-            $message->setCreatedAt(new \DateTime());
-            
+            $message->setStatus(random(MessageStatusEnum::cases()));
+
             $manager->persist($message);
         }
 

--- a/src/Entity/Message.php
+++ b/src/Entity/Message.php
@@ -2,15 +2,14 @@
 
 namespace App\Entity;
 
+use App\Enum\MessageStatusEnum;
 use App\Repository\MessageRepository;
-use DateTime;
+use DateTimeImmutable;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Uid\Uuid;
 
 #[ORM\Entity(repositoryClass: MessageRepository::class)]
-/**
- * TODO: Review Message class
- */
 class Message
 {
     #[ORM\Id]
@@ -19,32 +18,31 @@ class Message
     private ?int $id = null;
 
     #[ORM\Column(type: Types::GUID)]
-    private ?string $uuid = null;
+    private string $uuid;
 
     #[ORM\Column(length: 255)]
     private ?string $text = null;
 
-    #[ORM\Column(length: 255, nullable: true)]
-    private ?string $status = null;
+    #[ORM\Column(type: Types::STRING, length: 255, nullable: true, enumType: MessageStatusEnum::class)]
+    private ?MessageStatusEnum $status = null;
     
-    #[ORM\Column(type: 'datetime')]
-    private DateTime $createdAt;
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+    private DateTimeImmutable $createdAt;
+
+    public function __construct()
+    {
+        $this->uuid = Uuid::v6()->toRfc4122();
+        $this->createdAt = new DateTimeImmutable();
+    }
 
     public function getId(): ?int
     {
         return $this->id;
     }
 
-    public function getUuid(): ?string
+    public function getUuid(): Uuid
     {
-        return $this->uuid;
-    }
-
-    public function setUuid(string $uuid): static
-    {
-        $this->uuid = $uuid;
-
-        return $this;
+        return Uuid::fromString($this->uuid);
     }
 
     public function getText(): ?string
@@ -59,27 +57,20 @@ class Message
         return $this;
     }
 
-    public function getStatus(): ?string
+    public function getStatus(): ?MessageStatusEnum
     {
         return $this->status;
     }
 
-    public function setStatus(string $status): static
+    public function setStatus(MessageStatusEnum $status): static
     {
         $this->status = $status;
 
         return $this;
     }
 
-    public function getCreatedAt(): DateTime
+    public function getCreatedAt(): DateTimeImmutable
     {
         return $this->createdAt;
-    }
-
-    public function setCreatedAt(DateTime $createdAt): static
-    {
-        $this->createdAt = $createdAt;
-        
-        return $this;
     }
 }

--- a/src/Enum/MessageStatusEnum.php
+++ b/src/Enum/MessageStatusEnum.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enum;
+
+enum MessageStatusEnum: string
+{
+    case Sent = 'sent';
+    case Read = 'read';
+}

--- a/src/Message/SendMessageHandler.php
+++ b/src/Message/SendMessageHandler.php
@@ -21,10 +21,8 @@ class SendMessageHandler
     public function __invoke(SendMessage $sendMessage): void
     {
         $message = new Message();
-        $message->setUuid(Uuid::v6()->toRfc4122());
         $message->setText($sendMessage->text);
         $message->setStatus('sent');
-        $message->setCreatedAt(new \DateTime());
 
         $this->manager->persist($message);
         $this->manager->flush();


### PR DESCRIPTION
This commit introduces structural and semantic improvements to the Message entity, focusing on type safety and domain integrity.

Key changes:

    Replaced string-based status with a dedicated MessageStatusEnum, enforcing allowed values via native PHP enums.
    Introduced App\Enum\MessageStatusEnum with two cases: Sent and Read.
    Changed the $createdAt property to use DateTimeImmutable, eliminating unintended side effects of mutation.
    Made $uuid a non-nullable string and moved UUID generation into the constructor to standardize creation.
    Removed setters for uuid and createdAt, making these fields immutable after construction.
    Updated AppFixtures to randomly select enum cases using MessageStatusEnum::cases() instead of raw strings.
    Modified SendMessageHandler to stop manually setting uuid and createdAt, which are now handled internally.

These changes enforce domain rules directly in the type system, reduce boilerplate, and eliminate mutable fields that shouldn't be changed after entity construction.